### PR TITLE
composer update throws error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
   "autoload": {
     "psr-4": {
       "Sunnysideup\\Ecommerce\\": "src/",
-       "Sunnysideup\\Ecommerce\\Tests": "tests/"
+       "Sunnysideup\\Ecommerce\\Tests\\": "tests/"
     }
   }
 }


### PR DESCRIPTION
 psr-4 namespaces must end with a namespace separator, 'Sunnysideup\Ecommerce\Tests' does not, use 'Sunnysideup\Ecommerce\Tests\'.