### PR TITLE
Fix: current_ecommerce_db_config allows for the use of a custom ecomm…

### DIFF
--- a/code/model/config/EcommerceDBConfig.php
+++ b/code/model/config/EcommerceDBConfig.php
@@ -286,8 +286,8 @@ class EcommerceDBConfig extends DataObject implements EditableEcommerceObject
     {
         if (!self::$_my_current_one) {
             $className = EcommerceConfig::get('EcommerceDBConfig', 'ecommerce_db_config_class_name');
-            if (!class_exists('EcommerceDBConfig')) {
-                $class = 'EcommerceDBConfig';
+            if (!class_exists( $className )) {
+                $className = 'EcommerceDBConfig';
             }
             if (self::$_my_current_one = $className::get()->filter(array('UseThisOne' => 1))->first()) {
                 //do nothing


### PR DESCRIPTION
…erce db config class. It has a fallback mechanism that checks if the ecommerce_db_config_class_name actually exists. However this fallback did not check the existence of the custom class but of the default EcommerceDBConfig (the current class). Modified to class_exists the custom class and if not exists, replace $className (not $class) with the default 'EcommerceDBConfig'.